### PR TITLE
Refactor to make code less confusing

### DIFF
--- a/README.md
+++ b/README.md
@@ -85,9 +85,10 @@ local palette = require 'nordic.colors'
 Nordic will use the default values, unless `setup` is called.  Below is the default configuration.
 
 ```lua
-require 'nordic' .setup {
+local palette = require 'nordic.colors'
+require('nordic').setup {
     -- This callback can be used to override the colors used in the palette.
-    on_palette = function(palette) return palette end,
+    on_palette = function(color_palette) return color_palette end,
     -- Enable bold keywords.
     bold_keywords = false,
     -- Enable italic comments.
@@ -109,7 +110,7 @@ require 'nordic' .setup {
         -- Bold cursorline number.
         bold_number = true,
         -- Cursorline bg.
-        bg = '#191D24',
+        bg = palette.black0,
         -- Blending the cursorline bg with the buffer bg.
         blend = 0.85,
     },

--- a/README.md
+++ b/README.md
@@ -108,8 +108,8 @@ require 'nordic' .setup {
         bold = false,
         -- Bold cursorline number.
         bold_number = true,
-        -- Avialable styles: 'dark', 'light'.
-        theme = 'dark',
+        -- Cursorline bg.
+        bg = '#191D24',
         -- Blending the cursorline bg with the buffer bg.
         blend = 0.85,
     },

--- a/doc/nordic.nvim.txt
+++ b/doc/nordic.nvim.txt
@@ -117,9 +117,10 @@ Nordic will use the default values, unless `setup` is called. Below is the
 default configuration.
 
 >lua
-    require 'nordic' .setup {
+    local palette = require 'nordic.colors'
+    require('nordic').setup {
         -- This callback can be used to override the colors used in the palette.
-        on_palette = function(palette) return palette end,
+        on_palette = function(color_palette) return color_palette end,
         -- Enable bold keywords.
         bold_keywords = false,
         -- Enable italic comments.
@@ -140,8 +141,8 @@ default configuration.
             bold = false,
             -- Bold cursorline number.
             bold_number = true,
-            -- Avialable styles: 'dark', 'light'.
-            theme = 'dark',
+            -- Cursorline bg.
+            bg = palette.black0,
             -- Blending the cursorline bg with the buffer bg.
             blend = 0.85,
         },

--- a/lua/nordic/colors/init.lua
+++ b/lua/nordic/colors/init.lua
@@ -36,8 +36,7 @@ function C.extend_palette()
     C.bg_selected = U.blend(C.gray2, C.black0, 0.4)
     C.bg_fold = C.gray2
     -- Cursorline Background
-    C.bg_highlight = (options.transparent_bg and options.cursorline.bg)
-        or U.blend(options.cursorline.bg, C.bg, options.cursorline.blend)
+    C.bg_highlight = U.blend(options.cursorline.bg, C.bg, options.cursorline.blend)
     C.bg_visual = C.bg_highlight
 
     -- Borders

--- a/lua/nordic/colors/init.lua
+++ b/lua/nordic/colors/init.lua
@@ -1,10 +1,11 @@
 local U = require 'nordic.utils'
-local O = require('nordic.config').options
 local C = require 'nordic.colors.nordic'
 
 function C.extend_palette()
+    local options = require('nordic.config').options
+
     -- Modify the palette before generating colors.
-    C = O.on_palette(C)
+    C = options.on_palette(C)
 
     local diff_blend = 0.2
 
@@ -17,7 +18,7 @@ function C.extend_palette()
     C.grey5 = C.gray5
 
     -- Swap background
-    if O.swap_backgrounds then
+    if options.swap_backgrounds then
         local gray0 = C.gray0
         C.gray0 = C.black1
         C.black1 = gray0
@@ -27,19 +28,20 @@ function C.extend_palette()
     -- Some of the format is from @folke/tokyonight.nvim.
 
     -- Backgrounds
-    C.bg = (O.transparent_bg and C.none) or C.gray0
-    C.bg_dark = (O.transparent_bg and C.none) or C.black0
-    C.bg_highlight = U.blend(C.bg_dark, C.bg, O.cursorline.blend)
-    C.bg_visual = C.bg_highlight
-    C.bg_sidebar = (O.transparent_bg and C.none) or C.bg
-    C.bg_popup = (O.transparent_bg and C.none) or C.bg
+    C.bg = (options.transparent_bg and C.none) or C.gray0
+    C.bg_dark = (options.transparent_bg and C.none) or C.black0
+    C.bg_sidebar = (options.transparent_bg and C.none) or C.bg
+    C.bg_popup = (options.transparent_bg and C.none) or C.bg
     C.bg_statusline = C.bg_dark
     C.bg_selected = U.blend(C.gray2, C.black0, 0.4)
     C.bg_fold = C.gray2
+    -- Cursorline Background
+    C.bg_highlight = U.blend(options.cursorline.bg, C.bg, options.cursorline.blend)
+    C.bg_visual = C.bg_highlight
 
     -- Borders
-    C.border_fg = (O.bright_border and C.white0) or C.black0
-    C.border_bg = (O.transparent_bg and C.none) or C.bg
+    C.border_fg = (options.bright_border and C.white0) or C.black0
+    C.border_bg = (options.transparent_bg and C.none) or C.bg
 
     -- Foregrounds
     C.fg = C.white0
@@ -82,12 +84,6 @@ function C.extend_palette()
     C.warning = C.warn
     C.hint = C.green.bright
     C.info = C.blue2
-
-    -- Cursorline
-    if O.cursorline.theme == 'light' then
-        C.bg_highlight = U.blend(C.gray1, C.bg, O.cursorline.blend)
-        C.bg_visual = C.bg_highlight
-    end
 end
 
 return C

--- a/lua/nordic/colors/init.lua
+++ b/lua/nordic/colors/init.lua
@@ -21,18 +21,12 @@ function C.extend_palette()
     C.grey4 = C.gray4
     C.grey5 = C.gray5
 
-    -- Swap background
-    if options.swap_backgrounds then
-        local gray0 = C.gray0
-        C.gray0 = C.black1
-        C.black1 = gray0
-    end
-
     -- Define some use cases.
     -- Some of the format is from @folke/tokyonight.nvim.
 
     -- Backgrounds
-    C.bg = (options.transparent_bg and C.none) or C.gray0
+    C.bg = (options.transparent_bg and C.none) or
+        ((options.swap_backgrounds and C.black1) or C.gray0)
     C.bg_dark = (options.transparent_bg and C.none) or C.black0
     C.bg_sidebar = (options.transparent_bg and C.none) or C.bg
     C.bg_popup = (options.transparent_bg and C.none) or C.bg
@@ -63,7 +57,8 @@ function C.extend_palette()
     C.fg_popup_border = C.border_fg
 
     -- Floating windows
-    C.bg_float = (options.transparent_bg and C.none) or C.black1
+    C.bg_float = (options.transparent_bg and C.none) or
+        ((options.swap_backgrounds and C.gray0) or C.black1)
     C.fg_float = C.fg
     C.bg_float_border = C.bg_float
     C.fg_float_border = C.border_fg

--- a/lua/nordic/colors/init.lua
+++ b/lua/nordic/colors/init.lua
@@ -1,10 +1,7 @@
 local U = require 'nordic.utils'
 local C = require 'nordic.colors.nordic'
 
-C.extended = false
-
 function C.extend_palette()
-    C.extended = true
     local options = require('nordic.config').options
 
     -- `white0` is used as the default fg, and has a blue tint.
@@ -96,6 +93,6 @@ end
 
 -- Sometimes the palette is required before the theme has been loaded,
 -- so we need to extend the palette in those cases.
-if not C.extended then C.extend_palette() end
+C.extend_palette()
 
 return C

--- a/lua/nordic/colors/init.lua
+++ b/lua/nordic/colors/init.lua
@@ -4,8 +4,8 @@ local C = require 'nordic.colors.nordic'
 C.extended = false
 
 function C.extend_palette()
-   C.extended = true
-   local options = require('nordic.config').options
+    C.extended = true
+    local options = require('nordic.config').options
 
     -- Modify the palette before generating colors.
     C = options.on_palette(C)
@@ -39,7 +39,8 @@ function C.extend_palette()
     C.bg_selected = U.blend(C.gray2, C.black0, 0.4)
     C.bg_fold = C.gray2
     -- Cursorline Background
-    C.bg_highlight = U.blend(options.cursorline.bg, C.bg, options.cursorline.blend)
+    C.bg_highlight = (options.transparent_bg and options.cursorline.bg) or
+        U.blend(options.cursorline.bg, C.bg, options.cursorline.blend)
     C.bg_visual = C.bg_highlight
 
     -- Borders
@@ -61,7 +62,7 @@ function C.extend_palette()
     C.fg_popup_border = C.border_fg
 
     -- Floating windows
-    C.bg_float = (O.transparent_bg and C.none) or C.black1
+    C.bg_float = (options.transparent_bg and C.none) or C.black1
     C.fg_float = C.fg
     C.bg_float_border = C.bg_float
     C.fg_float_border = C.border_fg

--- a/lua/nordic/colors/init.lua
+++ b/lua/nordic/colors/init.lua
@@ -36,7 +36,8 @@ function C.extend_palette()
     C.bg_selected = U.blend(C.gray2, C.black0, 0.4)
     C.bg_fold = C.gray2
     -- Cursorline Background
-    C.bg_highlight = U.blend(options.cursorline.bg, C.bg, options.cursorline.blend)
+    C.bg_highlight = (options.transparent_bg and options.cursorline.bg)
+        or U.blend(options.cursorline.bg, C.bg, options.cursorline.blend)
     C.bg_visual = C.bg_highlight
 
     -- Borders

--- a/lua/nordic/colors/init.lua
+++ b/lua/nordic/colors/init.lua
@@ -7,6 +7,10 @@ function C.extend_palette()
     C.extended = true
     local options = require('nordic.config').options
 
+    -- `white0` is used as the default fg, and has a blue tint.
+    -- Reduce that amount of tint.
+    C.white0 = (options.reduced_blue and C.white0_reduce_blue) or C.white0_normal
+
     -- Modify the palette before generating colors.
     C = options.on_palette(C)
 

--- a/lua/nordic/colors/nordic.lua
+++ b/lua/nordic/colors/nordic.lua
@@ -1,8 +1,6 @@
 -- The Nord palette: https://www.nordtheme.com/.
 -- This file has a bunch of added colors.
 
-local O = require('nordic.config').options
-
 local palette = {
 
     none = 'NONE',
@@ -27,7 +25,8 @@ local palette = {
     gray5 = '#60728A',
 
     -- Dim white.
-    white0 = '#BBC3D4',
+    white0_normal = '#BBC3D4',
+    white0_reduce_blue = '#C0C8D8',
 
     -- Snow storm.
     white1 = '#D8DEE9',
@@ -74,9 +73,5 @@ local palette = {
         dim = '#A97EA1',
     },
 }
-
--- `white0` is used as the default fg, and has a blue tint.
--- Reduce that amount of tint.
-if O.reduced_blue then palette.white0 = '#C0C8D8' end
 
 return palette

--- a/lua/nordic/config.lua
+++ b/lua/nordic/config.lua
@@ -1,5 +1,7 @@
 local M = {}
 
+local palette = require("nordic.colors.nordic")
+
 local defaults = {
     -- This callback can be used to override the colors used in the palette.
     on_palette = function(palette)
@@ -26,7 +28,7 @@ local defaults = {
         -- Bold cursorline number.
         bold_number = true,
         -- Cursorline bg.
-        bg = '#191D24',
+        bg = palette.black0,
         -- Blending the cursorline bg with the buffer bg.
         blend = 0.85,
     },

--- a/lua/nordic/config.lua
+++ b/lua/nordic/config.lua
@@ -25,8 +25,8 @@ local defaults = {
         bold = false,
         -- Bold cursorline number.
         bold_number = true,
-        -- Avialable styles: 'dark', 'light'.
-        theme = 'dark',
+        -- Cursorline bg.
+        bg = '#191D24',
         -- Blending the cursorline bg with the buffer bg.
         blend = 0.85,
     },

--- a/lua/nordic/groups/integrations/noice.lua
+++ b/lua/nordic/groups/integrations/noice.lua
@@ -14,10 +14,10 @@ local groups = {
     NoiceCmdlineIcon = { bg = C.bg_float, fg = C.yellow.base },
     NoiceCmdlineIconSearch = { bg = C.bg_dark, fg = C.yellow.base },
 
-    NoicePopupBorder = { fg = C.black0, bg = C.black1 },
+    NoicePopupBorder = { fg = C.black0, bg = C.bg_float },
     NoiceCmdlinePopupBorder = { link = 'NoicePopupBorder' },
     NoiceCmdlinePopupBorderSearch = { link = 'NoicePopupBorder' },
-    NoiceCmdlinePopup = { bg = C.black1 },
+    NoiceCmdlinePopup = { bg = C.bg_float },
 }
 
 if O.noice.style == 'classic' then

--- a/lua/nordic/groups/integrations/nvim-dap-ui.lua
+++ b/lua/nordic/groups/integrations/nvim-dap-ui.lua
@@ -2,7 +2,7 @@ local C = require 'nordic.colors'
 
 return {
 
-    DapUINormal = { bg = C.black1 },
+    DapUINormal = { bg = C.bg_float },
 
     DapUIStop = { fg = C.red.bright, bold = true },
     DapUIRestart = { fg = C.green.bright, bold = true },

--- a/lua/nordic/groups/integrations/telescope.lua
+++ b/lua/nordic/groups/integrations/telescope.lua
@@ -31,13 +31,13 @@ local groups = {
 }
 
 if O.telescope.style == 'flat' then
-    groups.TelescopeNormal = { bg = C.black1 }
+    groups.TelescopeNormal = { bg = C.bg_float }
     groups.TelescopePromptNormal = { bg = C.black2 }
-    groups.TelescopeResultsNormal = { bg = C.black1 }
-    groups.TelescopePreviewNormal = { bg = C.black1 }
+    groups.TelescopeResultsNormal = { bg = C.bg_float }
+    groups.TelescopePreviewNormal = { bg = C.bg_float }
 
-    groups.TelescopeSelection = { bg = C.black1, fg = C.yellow.bright }
-    groups.TelescopeSelectionCaret = { fg = C.yellow.bright, bg = C.black1, bold = true }
+    groups.TelescopeSelection = { bg = C.bg_float, fg = C.yellow.bright }
+    groups.TelescopeSelectionCaret = { fg = C.yellow.bright, bg = C.bg_float, bold = true }
 
     groups.TelescopePreviewTitle = { bg = C.blue2, fg = C.black0, bold = true }
     groups.TelescopeResultsTitle = { bg = C.orange.base, fg = C.black0, bold = true }
@@ -46,11 +46,11 @@ if O.telescope.style == 'flat' then
 
     groups.TelescopeBorder = { fg = C.black0, bg = C.black0 }
     groups.TelescopePromptBorder = { bg = C.black2, fg = C.black0 }
-    groups.TelescopeResultsBorder = { bg = C.black1, fg = C.black0 }
-    groups.TelescopePreviewBorder = { bg = C.black1, fg = C.black0 }
+    groups.TelescopeResultsBorder = { bg = C.bg_float, fg = C.black0 }
+    groups.TelescopePreviewBorder = { bg = C.bg_float, fg = C.black0 }
 
-    groups.TelescopeMultiIcon = { fg = C.yellow.bright, bg = C.black1, bold = true }
-    groups.TelescopeMultiSelection = { bg = C.black1 }
+    groups.TelescopeMultiIcon = { fg = C.yellow.bright, bg = C.bg_float, bold = true }
+    groups.TelescopeMultiSelection = { bg = C.bg_float }
     groups.TelescopePromptPrefix = { bg = C.black2, fg = C.orange.bright }
 
     groups.TelescopePreviewLine = { bg = C.gray1 }

--- a/lua/nordic/groups/integrations/trouble.lua
+++ b/lua/nordic/groups/integrations/trouble.lua
@@ -2,7 +2,7 @@ local C = require 'nordic.colors'
 
 return {
 
-    TroubleNormal = { bg = C.black1 },
+    TroubleNormal = { bg = C.bg_float },
     TroubleText = { fg = C.fg },
 
     TroubleCount = { fg = C.white1, bg = C.gray2 },

--- a/lua/nordic/groups/integrations/which-key.lua
+++ b/lua/nordic/groups/integrations/which-key.lua
@@ -3,10 +3,10 @@ local C = require 'nordic.colors'
 return {
 
     WhichKey = { fg = C.yellow.base },
-    WhichKeyFloat = { bg = C.black1 },
+    WhichKeyFloat = { bg = C.bg_float },
     WhichKeyDesc = { fg = C.white0 },
     WhichKeyGroup = { fg = C.orange.bright, bold = true },
-    WhichKeyBorder = { fg = C.black0, bg = C.black1 },
+    WhichKeyBorder = { fg = C.black0, bg = C.bg_float },
 
     -- TODO: Unsure.
     WhichKeySeperator = {},

--- a/lua/nordic/groups/native/editor.lua
+++ b/lua/nordic/groups/native/editor.lua
@@ -62,7 +62,7 @@ local groups = {
     Question = { fg = C.info }, -- |hit-enter| prompt and yes/no questions
     QuickFixLine = { bg = C.bg_visual, bold = true }, -- Current |quickfix| item in the quickfix window. Combined with |hl-CursorLine| when the cursor is there.
 
-    Search = { bg = C.black1, fg = C.yellow.bright, bold = true, underline = true }, -- Last search pattern highlighting (see 'hlsearch').  Also used for similar items that need to stand out.
+    Search = { bg = C.bg_float, fg = C.yellow.bright, bold = true, underline = true }, -- Last search pattern highlighting (see 'hlsearch').  Also used for similar items that need to stand out.
     IncSearch = { bg = C.yellow.base, fg = C.black0, bold = true }, -- 'incsearch' highlighting; also used for the text replaced with ":s///c"
     CurSearch = { link = 'IncSearch' },
 
@@ -78,7 +78,7 @@ local groups = {
 
     TabLine = { bg = C.bg_statusline, fg = C.fg }, -- tab pages line, not active tab page label
     TabLineFill = { bg = C.black0, fg = C.none }, -- tab pages line, where there are no labels
-    TabLineSel = { fg = C.fg_bright, bg = C.gray0 }, -- tab pages line, active tab page label
+    TabLineSel = { fg = C.fg_bright, bg = C.bg }, -- tab pages line, active tab page label
 
     Title = { fg = C.fg_bright, bold = true }, -- titles for output from ":set all", ":autocmd" etc.
 

--- a/lua/nordic/groups/native/lsp.lua
+++ b/lua/nordic/groups/native/lsp.lua
@@ -27,7 +27,7 @@ return {
     DiagnosticUnderlineWarn = { undercurl = true, sp = C.warning }, -- Used to underline "Warning" diagnostics
     DiagnosticUnderlineInfo = { undercurl = true, sp = C.info }, -- Used to underline "Information" diagnostics
     DiagnosticUnderlineHint = { undercurl = true, sp = C.hint }, -- Used to underline "Hint" diagnostics
-    DiagnosticText = { bg = C.black1 },
+    DiagnosticText = { bg = C.bg_float },
 
     LspSignatureActiveParameter = { bg = C.gray3, bold = true },
     LspCodeLens = { fg = C.comment },

--- a/lua/nordic/groups/native/syntax.lua
+++ b/lua/nordic/groups/native/syntax.lua
@@ -75,7 +75,7 @@ return {
     htmlH2 = { fg = C.orange.base },
 
     Link = { fg = C.blue1, underline = true },
-    CodeBlock = { bg = C.black1, fg = C.fg },
+    CodeBlock = { bg = C.bg_float, fg = C.fg },
 
     mkdHeading = { link = 'htmlH1' },
     mkdCode = { link = 'CodeBlock' },


### PR DESCRIPTION
- feat(cursorline)!: add cursorline bg option for visual selection color

- Merge branch 'AlexvZyl:main' into hardcode-cursorline

- fix: visual selection will be set to cursorline_bg not none when transparent_bg is true.

- Revert "fix: visual selection will be set to cursorline_bg not none when transparent_bg is true."

- Merge branch 'main' into hardcode-cursorline

- fix(extend_palette): fix cursorline_bg set to none when transparent_bg is true.

- fix: reduce_blue updates on extend palette

- refactor: cleaned up first run of extend palette

- fix: swap_backgrounds is no longer just a toggle.

- feat(config): allow use of base palette in default config.